### PR TITLE
Openwrt 21.02 pr更新 2021.6.13

### DIFF
--- a/sound/shairport-sync/Makefile
+++ b/sound/shairport-sync/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shairport-sync
-PKG_VERSION:=3.3.7
-PKG_RELEASE:=1
+PKG_VERSION:=3.3.8
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikebrady/shairport-sync/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=7f8d4ecec53f2f681a962467bf09205568fc936c8c31a9ee07b1bd72d3d95b12
+PKG_HASH:=c92f9a2d86dd1138673abc66e0010c94412ad6a46da8f36c3d538f4fa6b9faca
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Mike Brady <mikebrady@eircom.net>
@@ -77,6 +77,7 @@ endef
 
 CONFIGURE_ARGS += \
 	--with-alsa \
+	--with-libdaemon \
 	--with-metadata
 
 ifeq ($(BUILD_VARIANT),openssl)

--- a/sound/shairport-sync/patches/010-no-cxx.patch
+++ b/sound/shairport-sync/patches/010-no-cxx.patch
@@ -25,7 +25,7 @@
  endif
 --- a/configure.ac
 +++ b/configure.ac
-@@ -19,7 +19,6 @@ with_os=`echo ${with_os} | tr '[[:upper:
+@@ -23,7 +23,6 @@ fi
  
  # Checks for programs.
  AC_PROG_CC


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
